### PR TITLE
Upgrade to mechanize 2.8.5

### DIFF
--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.rubygems_version = '1.3.7'
 
-  s.add_runtime_dependency('capybara', ['>= 3.0.0', '< 4'])
+  s.add_runtime_dependency('capybara', ['>= 3.0.0', '< 3.37.0'])
   s.add_runtime_dependency('mechanize', ['~> 2.8.5'])
 
   s.add_development_dependency('launchy', ['>= 2.0.4'])

--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = '1.3.7'
 
   s.add_runtime_dependency('capybara', ['>= 3.0.0', '< 4'])
-  s.add_runtime_dependency('mechanize', ['~> 2.7.0'])
+  s.add_runtime_dependency('mechanize', ['~> 2.8.5'])
 
   s.add_development_dependency('launchy', ['>= 2.0.4'])
   s.add_development_dependency('rake')


### PR DESCRIPTION
This resolves [CVE-2022-31033](https://nvd.nist.gov/vuln/detail/CVE-2022-31033). Related to #70 