### PR TITLE
Fix incompatibilities with Capybara 3.37.0 and 3.38.0

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -7,9 +7,16 @@ jobs:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', '3.1']
         gemfile:
-          - Gemfile
+          - puma5
+          - puma5_capybara36
+          - puma6
+        exclude:
+          - ruby-version: '2.6'
+            gemfile: puma6
+          - ruby-version: '2.6'
+            gemfile: puma5
     env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'puma'
+gem 'puma', '~> 6.0'
 gem 'sinatra', '~> 2.0'

--- a/capybara-mechanize.gemspec
+++ b/capybara-mechanize.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.rubygems_version = '1.3.7'
 
-  s.add_runtime_dependency('capybara', ['>= 3.0.0', '< 3.37.0'])
+  s.add_runtime_dependency('capybara', ['>= 3.0.0', '< 4'])
   s.add_runtime_dependency('mechanize', ['~> 2.8.5'])
 
   s.add_development_dependency('launchy', ['>= 2.0.4'])

--- a/gemfiles/puma5.gemfile
+++ b/gemfiles/puma5.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '..'
+
+gem 'capybara', '> 3.37'
+gem 'puma', '~> 5.0'
+gem 'sinatra', '~> 2.0'

--- a/gemfiles/puma5_capybara36.gemfile
+++ b/gemfiles/puma5_capybara36.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '..'
+
+gem 'capybara', '= 3.36'
+gem 'puma', '~> 5.0'
+gem 'sinatra', '~> 2.0'

--- a/gemfiles/puma6.gemfile
+++ b/gemfiles/puma6.gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'http://rubygems.org'
+
+gemspec path: '..'
+
+gem 'capybara', '> 3.37'
+gem 'puma', '~> 5.0'
+gem 'sinatra', '~> 2.0'

--- a/lib/capybara/mechanize/browser.rb
+++ b/lib/capybara/mechanize/browser.rb
@@ -34,7 +34,7 @@ class Capybara::Mechanize::Browser < Capybara::RackTest::Browser
   end
 
   def last_request
-    last_request_remote? ? OpenStruct.new(request_method: @last_method, params: @last_params) : super
+    last_request_remote? ? OpenStruct.new(request_method: @last_method, params: @last_params, url: remote_response.current_url) : super
   end
 
   # For each of these http methods, we want to intercept the method call.

--- a/lib/capybara/mechanize/node.rb
+++ b/lib/capybara/mechanize/node.rb
@@ -2,6 +2,7 @@
 
 class Capybara::Mechanize::Node < Capybara::RackTest::Node
   def click(keys = [], **options)
+    options.delete(:offset)
     raise ArgumentError, 'The mechanize driver does not support click options' unless keys.empty? && options.empty?
 
     submits = respond_to?(:submits?) ? submits? :


### PR DESCRIPTION
Fix URI::InvalidURIError when working with capybara 3.37.x
Fix ArgumentError: 'The mechanize driver does not support click options' when working with capybara 3.38.x