### PR TITLE
Require `ostruct` in Capybara::Mechanize::Browser

### DIFF
--- a/lib/capybara/mechanize/browser.rb
+++ b/lib/capybara/mechanize/browser.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'ostruct'
 require 'capybara/rack_test/driver'
 require 'mechanize'
 require 'capybara/mechanize/node'


### PR DESCRIPTION
The #last_request method uses the `OpenStruct` class, so we need to load it first.

I don’t know why this didn’t cause problems sooner. Perhaps a dependency used to `require 'ostruct'` and has stopped doing so in a newer version.